### PR TITLE
Make sure jmeter-server can run on nano instances & fix VM destroy

### DIFF
--- a/destroy-vm.yml
+++ b/destroy-vm.yml
@@ -3,9 +3,15 @@
   vars_files:
     - vars.yml
   tasks:
-    - name: Destroy lightsail VMs
+    - name: Destroy lightsail client VM
+      lightsail:
+        state: absent
+        name: "{{ vm.client }}"
+        region: "{{ vm.aws.region }}"
+
+    - name: Destroy lightsail server VMs
       lightsail:
         state: absent
         name: "{{ item }}"
         region: "{{ vm.aws.region }}"
-      with_items: "{{ vm.hosts }}"
+      with_items: "{{ vm.servers }}"

--- a/roles/jmeter-client/tasks/main.yml
+++ b/roles/jmeter-client/tasks/main.yml
@@ -37,3 +37,9 @@
     dest: "~/apache-jmeter-{{ jmeter.version }}/"
     remote_src: yes
   with_items: "{{ jmeter.plugins }}"
+
+- name: Set Java heap size
+  lineinfile:
+    path: "~/apache-jmeter-{{ jmeter.version }}/bin/jmeter"
+    regexp: '^HEAP='
+    line: 'HEAP="-Xms{{ java.memory }} -Xmx{{ java.memory }}"'

--- a/roles/jmeter-server/tasks/main.yml
+++ b/roles/jmeter-server/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
-- name: Start JMeter server in background
-  shell: "nohup bin/jmeter-server -Djava.rmi.server.hostname=$(ip route get 8.8.8.8 | head -1 | cut -d' ' -f8)  >/dev/null 2>&1 &"
-  args:
-    chdir: "~/apache-jmeter-{{ jmeter.version }}/"
+- name: Copy JMeter startup script
+  template:
+    src: jmeter.sh
+    dest: "~/apache-jmeter-{{ jmeter.version }}/jmeter.sh"
+    mode: 0755
+
+- name: Start JMeter server
+  shell: "~/apache-jmeter-{{ jmeter.version }}/jmeter.sh"

--- a/roles/jmeter-server/templates/jmeter.sh
+++ b/roles/jmeter-server/templates/jmeter.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd $(dirname $0)
+nohup bin/jmeter-server -Djava.rmi.server.hostname=$(ip route get 8.8.8.8 | head -1 | cut -d' ' -f8) > jmeter-server.log 2> jmeter-server.err &

--- a/vars.yml.dist
+++ b/vars.yml.dist
@@ -21,3 +21,6 @@ vm:
     - iotop
     - unzip
     - vim
+
+java:
+  memory: 400m


### PR DESCRIPTION
jmeter-server crashes with the default 512Mb heap allocation.

Destroy both client & server VMs in destroy-vm.yml
